### PR TITLE
update

### DIFF
--- a/HOWTO
+++ b/HOWTO
@@ -2346,6 +2346,14 @@ I/O replay
 
 	Scale sector offsets down by this factor when replaying traces.
 
+.. option:: replay_skip=str
+
+	Sometimes it's useful to skip certain IO types in a replay trace.
+	This could be, for instance, eliminating the writes in the trace.
+	Or not replaying the trims/discards, if you are redirecting to
+	a device that doesn't support them. This option takes a comma
+	separated list of read, write, trim, sync.
+
 
 Threads, processes and job synchronization
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Makefile
+++ b/Makefile
@@ -462,7 +462,7 @@ t/time-test: $(T_TT_OBJS)
 	$(QUIET_LINK)$(CC) $(LDFLAGS) $(CFLAGS) -o $@ $(T_TT_OBJS) $(LIBS)
 
 clean: FORCE
-	@rm -f .depend $(FIO_OBJS) $(GFIO_OBJS) $(OBJS) $(T_OBJS) $(PROGS) $(T_PROGS) $(T_TEST_PROGS) core.* core gfio FIO-VERSION-FILE *.d lib/*.d oslib/*.d crc/*.d engines/*.d profiles/*.d t/*.d config-host.mak config-host.h y.tab.[ch] lex.yy.c exp/*.[do] lexer.h
+	@rm -f .depend $(FIO_OBJS) $(GFIO_OBJS) $(OBJS) $(T_OBJS) $(PROGS) $(T_PROGS) $(T_TEST_PROGS) core.* core gfio FIO-VERSION-FILE *.[do] lib/*.d oslib/*.[do] crc/*.d engines/*.[do] profiles/*.[do] t/*.[do] config-host.mak config-host.h y.tab.[ch] lex.yy.c exp/*.[do] lexer.h
 	@rm -rf  doc/output
 
 distclean: clean FORCE

--- a/backend.c
+++ b/backend.c
@@ -1670,7 +1670,7 @@ static void *thread_main(void *data)
 	 * May alter parameters that init_io_u() will use, so we need to
 	 * do this first.
 	 */
-	if (init_iolog(td))
+	if (!init_iolog(td))
 		goto err;
 
 	if (init_io_u(td))

--- a/blktrace.c
+++ b/blktrace.c
@@ -273,6 +273,9 @@ static void handle_trace_discard(struct thread_data *td,
 	unsigned int bs;
 	int fileno;
 
+	if (td->o.replay_skip & (1u << DDIR_TRIM))
+		return;
+
 	ipo = calloc(1, sizeof(*ipo));
 	init_ipo(ipo);
 	fileno = trace_add_file(td, t->device, &bs);
@@ -312,6 +315,14 @@ static void handle_trace_fs(struct thread_data *td, struct blk_io_trace *t,
 
 	rw = (t->action & BLK_TC_ACT(BLK_TC_WRITE)) != 0;
 
+	if (rw) {
+		if (td->o.replay_skip & (1u << DDIR_WRITE))
+			return;
+	} else {
+		if (td->o.replay_skip & (1u << DDIR_READ))
+			return;
+	}
+
 	assert(t->bytes);
 
 	if (t->bytes > rw_bs[rw])
@@ -328,6 +339,9 @@ static void handle_trace_flush(struct thread_data *td, struct blk_io_trace *t,
 	struct io_piece *ipo;
 	unsigned int bs;
 	int fileno;
+
+	if (td->o.replay_skip & (1u << DDIR_SYNC))
+		return;
 
 	ipo = calloc(1, sizeof(*ipo));
 	init_ipo(ipo);

--- a/blktrace.c
+++ b/blktrace.c
@@ -312,13 +312,9 @@ static void handle_trace_fs(struct thread_data *td, struct blk_io_trace *t,
 
 	rw = (t->action & BLK_TC_ACT(BLK_TC_WRITE)) != 0;
 
-	/*
-	 * Need to figure out why 0 byte writes end up here sometimes, for
-	 * now just ignore them.
-	 */
-	if (!t->bytes)
-		return;
-	else if (t->bytes > rw_bs[rw])
+	assert(t->bytes);
+
+	if (t->bytes > rw_bs[rw])
 		rw_bs[rw] = t->bytes;
 
 	ios[rw]++;

--- a/blktrace.c
+++ b/blktrace.c
@@ -281,7 +281,6 @@ static void handle_trace_discard(struct thread_data *td,
 
 	td->o.size += t->bytes;
 
-	memset(ipo, 0, sizeof(*ipo));
 	INIT_FLIST_HEAD(&ipo->list);
 
 	ipo->offset = t->sector * bs;

--- a/blktrace.c
+++ b/blktrace.c
@@ -310,7 +310,13 @@ static void handle_trace_fs(struct thread_data *td, struct blk_io_trace *t,
 
 	rw = (t->action & BLK_TC_ACT(BLK_TC_WRITE)) != 0;
 
-	if (t->bytes > rw_bs[rw])
+	/*
+	 * Need to figure out why 0 byte writes end up here sometimes, for
+	 * now just ignore them.
+	 */
+	if (!t->bytes)
+		return;
+	else if (t->bytes > rw_bs[rw])
 		rw_bs[rw] = t->bytes;
 
 	ios[rw]++;

--- a/blktrace.c
+++ b/blktrace.c
@@ -222,8 +222,9 @@ static void store_ipo(struct thread_data *td, unsigned long long offset,
 		      unsigned int bytes, int rw, unsigned long long ttime,
 		      int fileno, unsigned int bs)
 {
-	struct io_piece *ipo = malloc(sizeof(*ipo));
+	struct io_piece *ipo;
 
+	ipo = calloc(1, sizeof(*ipo));
 	init_ipo(ipo);
 
 	ipo->offset = offset * bs;
@@ -268,10 +269,11 @@ static void handle_trace_discard(struct thread_data *td,
 				 unsigned long long ttime,
 				 unsigned long *ios, unsigned int *rw_bs)
 {
-	struct io_piece *ipo = malloc(sizeof(*ipo));
+	struct io_piece *ipo;
 	unsigned int bs;
 	int fileno;
 
+	ipo = calloc(1, sizeof(*ipo));
 	init_ipo(ipo);
 	fileno = trace_add_file(td, t->device, &bs);
 

--- a/blktrace.h
+++ b/blktrace.h
@@ -3,20 +3,20 @@
 
 #ifdef FIO_HAVE_BLKTRACE
 
-int is_blktrace(const char *, int *);
-int load_blktrace(struct thread_data *, const char *, int);
+bool is_blktrace(const char *, int *);
+bool load_blktrace(struct thread_data *, const char *, int);
 
 #else
 
-static inline int is_blktrace(const char *fname, int *need_swap)
+static inline bool is_blktrace(const char *fname, int *need_swap)
 {
-	return 0;
+	return false;
 }
 
-static inline int load_blktrace(struct thread_data *td, const char *fname,
-				int need_swap)
+static inline bool load_blktrace(struct thread_data *td, const char *fname,
+				 int need_swap)
 {
-	return 1;
+	return false;
 }
 
 #endif

--- a/blktrace_api.h
+++ b/blktrace_api.h
@@ -9,7 +9,7 @@
 enum {
 	BLK_TC_READ	= 1 << 0,	/* reads */
 	BLK_TC_WRITE	= 1 << 1,	/* writes */
-	BLK_TC_BARRIER	= 1 << 2,	/* barrier */
+	BLK_TC_FLUSH	= 1 << 2,	/* flush */
 	BLK_TC_SYNC	= 1 << 3,	/* sync */
 	BLK_TC_QUEUE	= 1 << 4,	/* queueing/merging */
 	BLK_TC_REQUEUE	= 1 << 5,	/* requeueing */

--- a/cconv.c
+++ b/cconv.c
@@ -290,6 +290,7 @@ void convert_thread_options_to_cpu(struct thread_options *o,
 	o->replay_align = le32_to_cpu(top->replay_align);
 	o->replay_scale = le32_to_cpu(top->replay_scale);
 	o->replay_time_scale = le32_to_cpu(top->replay_time_scale);
+	o->replay_skip = le32_to_cpu(top->replay_skip);
 	o->per_job_logs = le32_to_cpu(top->per_job_logs);
 	o->write_bw_log = le32_to_cpu(top->write_bw_log);
 	o->write_lat_log = le32_to_cpu(top->write_lat_log);
@@ -479,6 +480,7 @@ void convert_thread_options_to_net(struct thread_options_pack *top,
 	top->replay_align = cpu_to_le32(o->replay_align);
 	top->replay_scale = cpu_to_le32(o->replay_scale);
 	top->replay_time_scale = cpu_to_le32(o->replay_time_scale);
+	top->replay_skip = cpu_to_le32(o->replay_skip);
 	top->per_job_logs = cpu_to_le32(o->per_job_logs);
 	top->write_bw_log = cpu_to_le32(o->write_bw_log);
 	top->write_lat_log = cpu_to_le32(o->write_lat_log);

--- a/fio.1
+++ b/fio.1
@@ -2067,6 +2067,12 @@ value.
 Scale sector offsets down by this factor when replaying traces.
 .SS "Threads, processes and job synchronization"
 .TP
+.BI replay_skip \fR=\fPstr
+Sometimes it's useful to skip certain IO types in a replay trace. This could
+be, for instance, eliminating the writes in the trace. Or not replaying the
+trims/discards, if you are redirecting to a device that doesn't support them.
+This option takes a comma separated list of read, write, trim, sync.
+.TP
 .BI thread
 Fio defaults to creating jobs by using fork, however if this option is
 given, fio will create jobs by using POSIX Threads' function

--- a/iolog.c
+++ b/iolog.c
@@ -211,7 +211,7 @@ void log_io_piece(struct thread_data *td, struct io_u *io_u)
 	struct fio_rb_node **p, *parent;
 	struct io_piece *ipo, *__ipo;
 
-	ipo = malloc(sizeof(struct io_piece));
+	ipo = calloc(1, sizeof(struct io_piece));
 	init_ipo(ipo);
 	ipo->file = io_u->file;
 	ipo->offset = io_u->offset;
@@ -440,7 +440,7 @@ static int read_iolog2(struct thread_data *td, FILE *f)
 		/*
 		 * Make note of file
 		 */
-		ipo = malloc(sizeof(*ipo));
+		ipo = calloc(1, sizeof(*ipo));
 		init_ipo(ipo);
 		ipo->ddir = rw;
 		if (rw == DDIR_WAIT) {

--- a/iolog.c
+++ b/iolog.c
@@ -580,7 +580,7 @@ bool init_iolog(struct thread_data *td)
 	} else if (td->o.write_iolog_file)
 		ret = init_iolog_write(td);
 	else
-		ret = false;
+		ret = true;
 
 	if (!ret)
 		td_verror(td, EINVAL, "failed initializing iolog");

--- a/iolog.h
+++ b/iolog.h
@@ -234,7 +234,7 @@ struct io_u;
 extern int __must_check read_iolog_get(struct thread_data *, struct io_u *);
 extern void log_io_u(const struct thread_data *, const struct io_u *);
 extern void log_file(struct thread_data *, struct fio_file *, enum file_log_act);
-extern int __must_check init_iolog(struct thread_data *td);
+extern bool __must_check init_iolog(struct thread_data *td);
 extern void log_io_piece(struct thread_data *, struct io_u *);
 extern void unlog_io_piece(struct thread_data *, struct io_u *);
 extern void trim_io_piece(struct thread_data *, const struct io_u *);

--- a/iolog.h
+++ b/iolog.h
@@ -296,7 +296,7 @@ extern int iolog_cur_flush(struct io_log *, struct io_logs *);
 
 static inline void init_ipo(struct io_piece *ipo)
 {
-	memset(ipo, 0, sizeof(*ipo));
+	INIT_FLIST_HEAD(&ipo->list);
 	INIT_FLIST_HEAD(&ipo->trim_list);
 }
 

--- a/server.h
+++ b/server.h
@@ -48,7 +48,7 @@ struct fio_net_cmd_reply {
 };
 
 enum {
-	FIO_SERVER_VER			= 72,
+	FIO_SERVER_VER			= 73,
 
 	FIO_SERVER_MAX_FRAGMENT_PDU	= 1024,
 	FIO_SERVER_MAX_CMD_MB		= 2048,

--- a/thread_options.h
+++ b/thread_options.h
@@ -316,6 +316,7 @@ struct thread_options {
 	unsigned int replay_align;
 	unsigned int replay_scale;
 	unsigned int replay_time_scale;
+	unsigned int replay_skip;
 
 	unsigned int per_job_logs;
 
@@ -590,6 +591,7 @@ struct thread_options_pack {
 	uint32_t replay_align;
 	uint32_t replay_scale;
 	uint32_t replay_time_scale;
+	uint32_t replay_skip;
 
 	uint32_t per_job_logs;
 


### PR DESCRIPTION

blktrace: don't re-clear ipo  …
acaba88
 @axboe
axboe
blktrace: ignore 0 byte writes  …
897c606
 @axboe
axboe
iolog: always use calloc() and always init both lists  …
8812d7f
 @axboe
axboe
blktrace: change barrier to a flush  …
b359f03
 @axboe
axboe
blktrace: handle flush/sync replay  …
65c42cc
 @axboe
axboe
blktrace: kill zero sized write test  …
c1f22c2
 @axboe
axboe
blktrace: add 'reply_skip' option  …
d7235ef
 @axboe
axboe
Makefile: ensure we kill all object files  …
506df34
 @axboe
axboe
Update documentation for 'replay_skip'  …
38f6890
 @axboe
axboe
blktrace: make sure to account SYNC/TRIM at load time  …
811f542
 @axboe
axboe
iolog/blktrace: boolean conversion  …
b153f94
 @axboe
axboe
iolog: default to good return